### PR TITLE
Don't return json value as a string

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -3,6 +3,7 @@ from flask import Flask
 from flask import jsonify
 from personlista import personlista
 from redis import StrictRedis
+import json
 
 
 APP = Flask(__name__)
@@ -23,18 +24,18 @@ def fetch_data():
 	personlista.fetch_data(PL)
 
 	filt_data = personlista.get_output_data(PL)
-	REDIS.hmset("personlista", filt_data)
+	REDIS.set("personlista",json.dumps(filt_data));
 
 @APP.before_request
 def connect_to_data():
-	if REDIS.hexists("personlista","0") is False:
+	if REDIS.exists("personlista") is False:
 		print("PL is None, forced to fetch new. This shall not happen.")
 		fetch_data()
 
 @APP.route("/api/personlista")
 def get_filt():
-	personlista = REDIS.hgetall("personlista")
-	return jsonify(personlista['data'])
+	personlista = REDIS.get("personlista")
+	return jsonify(json.loads(personlista))
 
 @APP.route("/api")
 def welcome():

--- a/api/personlista.py
+++ b/api/personlista.py
@@ -30,7 +30,7 @@ class personlista:
 		r = requests.get(url)
 
 		try:
-			fetched_data = r.json();
+			fetched_data = r.json()
 		except:
 			raise(ValueError('Non-json format received from url: %') % url)
 
@@ -62,7 +62,7 @@ class personlista:
 						 'tilltalsnamn' : p['tilltalsnamn'],
 						 'valkrets'     : p['valkrets']})
 
-		self.output_data = {'data' : filtered_entries};
+		self.output_data = {'persons' : filtered_entries};
 
 
 	def get_output_data(self):


### PR DESCRIPTION
Instead of storing the "list of persons" as a key : value pair,  in REDIS, store the entire dict as a str and call json.loads() before returning