### PR TITLE
Added assignments for all members

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -50,7 +50,8 @@ def fetch_data():
     REDIS.set("members", json.dumps(filt_data))
 
     for p in filt_data['members']:
-        REDIS.set(p['member_id'], json.dumps(p))
+        member_data = members.get_member_data(MP, p['member_id'])
+        REDIS.set(p['member_id'], json.dumps(member_data))
 
 
 @APP.before_request


### PR DESCRIPTION
La till lite ny data under varje member. 

Denna datan kommer inte med när vi hämtar /api/members-datan.

Skulle kunna filtrera bort mer data från /api/members/ och endast skicka den datan för respektive member, dvs /api/member/<id> för att hålla nere datamängden om så önskas.